### PR TITLE
feat(cypress): add "match" custom assertion for subject, body, adresses, and headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,9 @@ expect(messageEvents.events[0]).to.have.subject.not.equals('Foo');
 
 expect(messageEvents.events[0]).to.have.subject.contains('Hello world!');
 expect(messageEvents.events[0]).to.have.subject.not.contains('Foo');
+
+expect(messageEvents.events[0]).to.have.subject.match(/^Hello /);
+expect(messageEvents.events[0]).to.have.subject.not.match(/^Goodbye/);
 ```
 
 ##### `body(type)`
@@ -241,15 +244,25 @@ expect(messageEvents.events[0]).to.have.subject.not.contains('Foo');
 Assert email's text or HTML body.
 
 ```js
+// Body "text"
 expect(messageEvents.events[0]).to.have.body('text').equal('Hello world!');
-expect(messageEvents.events[0]).to.have.body('text').contains('Hello');
 expect(messageEvents.events[0]).to.have.body('text').not.equal('Foo');
+
+expect(messageEvents.events[0]).to.have.body('text').contains('Hello');
 expect(messageEvents.events[0]).to.have.body('text').not.contains('Foo');
 
+expect(messageEvents.events[0]).to.have.body('text').match('[a-z]+');
+expect(messageEvents.events[0]).to.have.body('text').not.match('[a-z]+');"
+
+// Body "HTML"
 expect(messageEvents.events[0]).to.have.body('html').equal('<h1>Hello world!</h1>');
-expect(messageEvents.events[0]).to.have.body('html').contains('Hello world!');
 expect(messageEvents.events[0]).to.have.body('html').not.equal('Foo');
+
+expect(messageEvents.events[0]).to.have.body('html').contains('Hello world!');
 expect(messageEvents.events[0]).to.have.body('html').not.contains('Foo');
+
+expect(messageEvents.events[0]).to.have.body('html').match('[a-z]+');
+expect(messageEvents.events[0]).to.have.body('html').not.match('[a-z]+');
 ```
 
 ##### `header(name)`
@@ -258,8 +271,17 @@ Assert email's headers.
 
 ```js
 expect(messageEvents.events[0]).to.have.header('From');
-expect(messageEvents.events[0]).to.have.header('From').eq('symfony-mailer-testing@example.com');
 expect(messageEvents.events[0]).to.not.have.header('Foobar');
+
+expect(messageEvents.events[0]).to.have.header('From').equal('symfony-mailer-testing@example.com');
+expect(messageEvents.events[0]).to.have.header('From').not.equal('foo@example.com');
+
+expect(messageEvents.events[0])
+  .to.have.header('From')
+  .match(/[a-z]+@example.com/);
+expect(messageEvents.events[0])
+  .to.have.header('From')
+  .not.match(/[a-z0-9]+@example.com/);
 ```
 
 ##### `address(type)`
@@ -268,6 +290,11 @@ Assert email's address.
 
 ```js
 expect(messageEvents.events[0]).to.have.address('From');
-expect(messageEvents.events[0]).to.have.address('From').eq('symfony-mailer-testing@example.com');
 expect(messageEvents.events[0]).to.not.have.address('Foobar');
+
+expect(messageEvents.events[0]).to.have.address('From').equal('symfony-mailer-testing@example.com');
+expect(messageEvents.events[0]).to.have.address('From').not.equal('foo@example.com');
+
+expect(messageEvents.events[0]).to.have.address('From').match(/[a-z]+@example.com/);
+expect(messageEvents.events[0]).to.have.address('From').not.match(/[a-z0-9]+@example.com);
 ```

--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ expect(messageEvents.events[0]).to.have.body('text').contains('Hello');
 expect(messageEvents.events[0]).to.have.body('text').not.contains('Foo');
 
 expect(messageEvents.events[0]).to.have.body('text').match('[a-z]+');
-expect(messageEvents.events[0]).to.have.body('text').not.match('[a-z]+');"
+expect(messageEvents.events[0]).to.have.body('text').not.match('[a-z]+');
 
 // Body "HTML"
 expect(messageEvents.events[0]).to.have.body('html').equal('<h1>Hello world!</h1>');

--- a/tests/Bridge/Cypress/specs/email.spec.js
+++ b/tests/Bridge/Cypress/specs/email.spec.js
@@ -63,8 +63,14 @@ describe('I test an email', function () {
     sendEmail({ subject: 'Hello world!' });
 
     cy.getMessageEvents().then((messageEvents) => {
+      expect(messageEvents.events[0]).to.have.subject.equal('Hello world!');
+      expect(messageEvents.events[0]).to.have.subject.not.equal('Foo');
+
       expect(messageEvents.events[0]).to.have.subject.contains('Hello world!');
       expect(messageEvents.events[0]).to.have.subject.not.contains('Foo');
+
+      expect(messageEvents.events[0]).to.have.subject.match(/^Hello/);
+      expect(messageEvents.events[0]).to.have.subject.not.match(/^Bye/);
     });
   });
 
@@ -80,11 +86,15 @@ describe('I test an email', function () {
       expect(messageEvents.events[0]).to.have.body('text').not.eq('Foo bar');
       expect(messageEvents.events[0]).to.have.body('text').contains('text');
       expect(messageEvents.events[0]).to.have.body('text').not.contains('Foo bar');
+      expect(messageEvents.events[0]).to.have.body('text').match(/text$/);
+      expect(messageEvents.events[0]).to.have.body('text').not.match(/foo/);
 
       expect(messageEvents.events[0]).to.have.body('html').eq('<b>My HTML</b>');
       expect(messageEvents.events[0]).to.have.body('html').not.eq('<b>Foo bar</b>');
       expect(messageEvents.events[0]).to.have.body('html').contains('HTML</b>');
       expect(messageEvents.events[0]).to.have.body('html').not.contains('bar</b>');
+      expect(messageEvents.events[0]).to.have.body('html').match(/HTML/);
+      expect(messageEvents.events[0]).to.have.body('html').not.match(/text/);
     });
   });
 
@@ -96,8 +106,14 @@ describe('I test an email', function () {
       expect(messageEvents.events[0]).to.have.header('from');
       expect(messageEvents.events[0]).to.have.header('From').eq('symfony-mailer-testing@example.com');
       expect(messageEvents.events[0]).to.have.header('From').contains('symfony-mailer-testing@example.com');
+      expect(messageEvents.events[0])
+        .to.have.header('From')
+        .matches(/[a-z-]+@example.com/);
 
       expect(messageEvents.events[0]).to.not.have.header('Foobar');
+      expect(messageEvents.events[0])
+        .to.have.header('From')
+        .not.matches(/[0-9-]+@example.com/);
     });
   });
 
@@ -108,6 +124,9 @@ describe('I test an email', function () {
       expect(messageEvents.events[0]).to.have.address('From').eq('symfony-mailer-testing@example.com');
       expect(messageEvents.events[0]).to.have.address('From').contains('symfony-mailer-testing@example.com');
       expect(messageEvents.events[0]).to.have.address('To').contains('john@example.com');
+      expect(messageEvents.events[0])
+        .to.have.header('From')
+        .matches(/[a-z-]+@example.com/);
     });
   });
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->

<!--
Write a short README entry for your feature/bugfix here (replace this comment block.),
this will help people understand your PR.
-->

Added the possibility to match subject, body, addresses, and headers:

```js
expect(messageEvents.events[0]).to.have.subject.match(/^Hello /);
expect(messageEvents.events[0]).to.have.subject.not.match(/^Goodbye/);

expect(messageEvents.events[0]).to.have.body('text').match('[a-z]+');
expect(messageEvents.events[0]).to.have.body('text').not.match('[a-z]+');

expect(messageEvents.events[0]).to.have.body('html').match('[a-z]+');
expect(messageEvents.events[0]).to.have.body('html').not.match('[a-z]+');

expect(messageEvents.events[0]).to.have.header('From').match(/[a-z]+@example.com/);
expect(messageEvents.events[0]).to.have.header('From').not.match(/[a-z0-9]+@example.com/);

expect(messageEvents.events[0]).to.have.address('From').match(/[a-z]+@example.com/);
expect(messageEvents.events[0]).to.have.address('From').not.match(/[a-z0-9]+@example.com);
```