### PR TITLE
feat(behat): add new assertions if text/html body matches or not, close #11

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,10 +128,12 @@ Available steps:
 - `@Then this email is queued`
 - `@Then this email is not queued`
 - `@Then this email has :count attachment(s)`
-- `@Then this email text body contains :text`
-- `@Then this email text body not contains :text`
+- `@Then this email text body matches :regex`
+- `@Then this email text body not matches :regex`
 - `@Then this email HTML body contains :text`
 - `@Then this email HTML body not contains :text`
+- `@Then this email HTML body matches :regex`
+- `@Then this email HTML body not matches :regex`
 - `@Then this email has header :headerName`
 - `@Then this email has no header :headerName`
 - `@Then this email header :headerName has value :value`

--- a/README.md
+++ b/README.md
@@ -25,6 +25,16 @@ This testing library provides the same [PHPUnit assertions for Email Messages](h
 - `assertEmailHeaderNotSame`
 - `assertEmailAddressContains`
 
+With additional assertions:
+
+- `assertEmailSubjectSame`
+- `assertEmailSubjectContains`
+- `assertEmailSubjectMatches`
+- `assertEmailTextBodyMatches`
+- `assertEmailTextBodyNotMatches`
+- `assertEmailHtmlBodyMatches`
+- `assertEmailHtmlBodyNotMatches`
+
 ## Installation
 
 ```console

--- a/src/Bridge/Behat/MailerContextTrait.php
+++ b/src/Bridge/Behat/MailerContextTrait.php
@@ -85,4 +85,36 @@ trait MailerContextTrait
     {
         $this->mailerAssertions->assertEmailSubjectMatches($this->getSelectedMessageEvent()->getMessage(), $regex);
     }
+
+    /**
+     * @Then this email text body matches :regex
+     */
+    public function thisEmailTextBodyMatches(string $regex): void
+    {
+        $this->mailerAssertions->assertEmailTextBodyMatches($this->getSelectedMessageEvent()->getMessage(), $regex);
+    }
+
+    /**
+     * @Then this email text body not matches :regex
+     */
+    public function thisEmailTextBodyNotMatches(string $regex): void
+    {
+        $this->mailerAssertions->assertEmailTextBodyNotMatches($this->getSelectedMessageEvent()->getMessage(), $regex);
+    }
+
+    /**
+     * @Then this email HTML body matches :regex
+     */
+    public function thisEmailHtmlBodyMatches(string $regex): void
+    {
+        $this->mailerAssertions->assertEmailHtmlBodyMatches($this->getSelectedMessageEvent()->getMessage(), $regex);
+    }
+
+    /**
+     * @Then this email HTML body not matches :regex
+     */
+    public function thisEmailHtmlBodyNotMatches(string $regex): void
+    {
+        $this->mailerAssertions->assertEmailHtmlBodyNotMatches($this->getSelectedMessageEvent()->getMessage(), $regex);
+    }
 }

--- a/src/Test/MailerAssertions.php
+++ b/src/Test/MailerAssertions.php
@@ -41,4 +41,48 @@ class MailerAssertions
             $email->getSubject()
         ));
     }
+
+    public function assertEmailTextBodyMatches(RawMessage $email, string $regex, ?string $message=null): void
+    {
+        Assert::isInstanceOf($email, Email::class);
+        Assert::nullOrString($email->getTextBody());
+        Assert::regex($email->getTextBody() ?? '', $regex, sprintf(
+            $message ?? 'Failed asserting that the Email text body matches pattern "%s". Got "%s".',
+            $regex,
+            $email->getTextBody()
+        ));
+    }
+
+    public function assertEmailTextBodyNotMatches(RawMessage $email, string $regex, ?string $message=null): void
+    {
+        Assert::isInstanceOf($email, Email::class);
+        Assert::nullOrString($email->getTextBody());
+        Assert::notRegex($email->getTextBody() ?? '', $regex, sprintf(
+            $message ?? 'Failed asserting that the Email text body not matches pattern "%s". Got "%s".',
+            $regex,
+            $email->getTextBody()
+        ));
+    }
+
+    public function assertEmailHtmlBodyMatches(RawMessage $email, string $regex, ?string $message=null): void
+    {
+        Assert::isInstanceOf($email, Email::class);
+        Assert::nullOrString($email->getHtmlBody());
+        Assert::regex($email->getHtmlBody() ?? '', $regex, sprintf(
+            $message ?? 'Failed asserting that the Email HTML body matches pattern "%s". Got "%s".',
+            $regex,
+            $email->getHtmlBody()
+        ));
+    }
+
+    public function assertEmailHtmlBodyNotMatches(RawMessage $email, string $regex, ?string $message=null): void
+    {
+        Assert::isInstanceOf($email, Email::class);
+        Assert::nullOrString($email->getHtmlBody());
+        Assert::notRegex($email->getHtmlBody() ?? '', $regex, sprintf(
+            $message ?? 'Failed asserting that the Email HTML body not matches pattern "%s". Got "%s".',
+            $regex,
+            $email->getHtmlBody()
+        ));
+    }
 }

--- a/tests/Bridge/Behat/email.feature
+++ b/tests/Bridge/Behat/email.feature
@@ -43,6 +43,8 @@ Feature: Testing emails
     Then I select email #0
     And this email text body contains "Hi Carla!"
     And this email text body not contains "Bye Carla!"
+    And this email text body matches "#Hi [a-zA-Z]+!#"
+    And this email text body not matches "#Bye [a-zA-Z]+!#"
 
   Scenario: I can test if emails HTML body contains
     When I send an email:
@@ -54,6 +56,8 @@ Feature: Testing emails
     Then I select email #0
     And this email HTML body contains "<b>Hi Carla!</b>"
     And this email HTML body not contains "Bye Carla!"
+    And this email HTML body matches "#Hi [a-zA-Z]+!#"
+    And this email HTML body not matches "#Bye [a-zA-Z]+!#"
 
   Scenario: I can test emails headers
     When I send an email:

--- a/tests/MailerAssertionsTest.php
+++ b/tests/MailerAssertionsTest.php
@@ -228,6 +228,42 @@ class MailerAssertionsTest extends TestCase
         $this->mailerAssertions->assertEmailTextBodyNotContains($email, 'world');
     }
 
+    public function testAssertEmailTextBodyMatches(): void
+    {
+        $email = $this->createEmail()->text('Hello world');
+
+        $this->mailerAssertions->assertEmailTextBodyMatches($email, '/world/');
+
+        $this->addToAssertionCount(1);
+    }
+
+    public function testAssertEmailTextBodyMatchesFailing(): void
+    {
+        $this->expectExceptionMessage('Failed asserting that the Email text body matches pattern "/moon/". Got "Hello world".');
+
+        $email = $this->createEmail()->text('Hello world');
+
+        $this->mailerAssertions->assertEmailTextBodyMatches($email, '/moon/');
+    }
+
+    public function testAssertEmailTextBodyNotMatches(): void
+    {
+        $email = $this->createEmail()->text('Hello world');
+
+        $this->mailerAssertions->assertEmailTextBodyNotMatches($email, '/moon/');
+
+        $this->addToAssertionCount(1);
+    }
+
+    public function testAssertEmailTextBodyNotMatchesFailing(): void
+    {
+        $this->expectExceptionMessage('Failed asserting that the Email text body not matches pattern "/world/". Got "Hello world".');
+
+        $email = $this->createEmail()->text('Hello world');
+
+        $this->mailerAssertions->assertEmailTextBodyNotMatches($email, '/world/');
+    }
+
     public function testAssertEmailHtmlBodyContains(): void
     {
         $email = $this->createEmail()->html('<b>Hello world</b>');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #11   <!-- #-prefixed issue number(s), if any -->

<!--
Write a short README entry for your feature/bugfix here (replace this comment block.),
this will help people understand your PR.
-->

Add new assertions for testing if text and html body matches (or not) to a regex.

Add Behat support:
- `@Then this email text body matches :regex`
- `@Then this email text body not matches :regex`
- `@Then this email HTML body matches :regex`
- `@Then this email HTML body not matches :regex`