### PR TITLE
feat(behat): add new assertions if has attachment with name is same or matches, close #12

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ With additional assertions:
 - `assertEmailTextBodyNotMatches`
 - `assertEmailHtmlBodyMatches`
 - `assertEmailHtmlBodyNotMatches`
+- `assertEmailAttachmentNameSame`
+- `assertEmailAttachmentNameMatches`
 
 ## Installation
 

--- a/src/Bridge/Behat/MailerContextTrait.php
+++ b/src/Bridge/Behat/MailerContextTrait.php
@@ -117,4 +117,20 @@ trait MailerContextTrait
     {
         $this->mailerAssertions->assertEmailHtmlBodyNotMatches($this->getSelectedMessageEvent()->getMessage(), $regex);
     }
+
+    /**
+     * @Then this email has attachment named :name
+     */
+    public function thisEmailHasAttachmentNamed(string $name): void
+    {
+        $this->mailerAssertions->assertEmailAttachmentNameSame($this->getSelectedMessageEvent()->getMessage(), $name);
+    }
+
+    /**
+     * @Then this email has attachment name matching :regex
+     */
+    public function thisEmailHasAttachmentNameMatching(string $regex): void
+    {
+        $this->mailerAssertions->assertEmailAttachmentNameMatches($this->getSelectedMessageEvent()->getMessage(), $regex);
+    }
 }

--- a/src/Test/MailerAssertions.php
+++ b/src/Test/MailerAssertions.php
@@ -6,6 +6,7 @@ namespace Kocal\SymfonyMailerTesting\Test;
 
 use Kocal\SymfonyMailerTesting\MailerLogger;
 use Symfony\Component\Mime\Email;
+use Symfony\Component\Mime\Part\DataPart;
 use Symfony\Component\Mime\RawMessage;
 use Webmozart\Assert\Assert;
 
@@ -42,7 +43,7 @@ class MailerAssertions
         ));
     }
 
-    public function assertEmailTextBodyMatches(RawMessage $email, string $regex, ?string $message=null): void
+    public function assertEmailTextBodyMatches(RawMessage $email, string $regex, ?string $message = null): void
     {
         Assert::isInstanceOf($email, Email::class);
         Assert::nullOrString($email->getTextBody());
@@ -53,7 +54,7 @@ class MailerAssertions
         ));
     }
 
-    public function assertEmailTextBodyNotMatches(RawMessage $email, string $regex, ?string $message=null): void
+    public function assertEmailTextBodyNotMatches(RawMessage $email, string $regex, ?string $message = null): void
     {
         Assert::isInstanceOf($email, Email::class);
         Assert::nullOrString($email->getTextBody());
@@ -64,7 +65,7 @@ class MailerAssertions
         ));
     }
 
-    public function assertEmailHtmlBodyMatches(RawMessage $email, string $regex, ?string $message=null): void
+    public function assertEmailHtmlBodyMatches(RawMessage $email, string $regex, ?string $message = null): void
     {
         Assert::isInstanceOf($email, Email::class);
         Assert::nullOrString($email->getHtmlBody());
@@ -75,7 +76,7 @@ class MailerAssertions
         ));
     }
 
-    public function assertEmailHtmlBodyNotMatches(RawMessage $email, string $regex, ?string $message=null): void
+    public function assertEmailHtmlBodyNotMatches(RawMessage $email, string $regex, ?string $message = null): void
     {
         Assert::isInstanceOf($email, Email::class);
         Assert::nullOrString($email->getHtmlBody());
@@ -83,6 +84,48 @@ class MailerAssertions
             $message ?? 'Failed asserting that the Email HTML body not matches pattern "%s". Got "%s".',
             $regex,
             $email->getHtmlBody()
+        ));
+    }
+
+    public function assertEmailAttachmentNameSame(RawMessage $email, string $attachmentName, ?string $message = null): void
+    {
+        Assert::isInstanceOf($email, Email::class);
+
+        $matches = (function () use ($email, $attachmentName): bool {
+            /** @var DataPart $attachment */
+            foreach ($email->getAttachments() as $attachment) {
+                if ($attachmentName === $attachment->getPreparedHeaders()->getHeaderParameter('Content-Disposition', 'filename')) {
+                    return true;
+                }
+            }
+
+            return false;
+        })();
+
+        Assert::true($matches, sprintf(
+            $message ?? 'Failed asserting that the Email has an attachment with name "%s".',
+            $attachmentName,
+        ));
+    }
+
+    public function assertEmailAttachmentNameMatches(RawMessage $email, string $attachmentNamePattern, ?string $message = null): void
+    {
+        Assert::isInstanceOf($email, Email::class);
+
+        $matches = (function () use ($email, $attachmentNamePattern): bool {
+            /** @var DataPart $attachment */
+            foreach ($email->getAttachments() as $attachment) {
+                if (1 === preg_match($attachmentNamePattern, $attachment->getPreparedHeaders()->getHeaderParameter('Content-Disposition', 'filename') ?? '')) {
+                    return true;
+                }
+            }
+
+            return false;
+        })();
+
+        Assert::true($matches, sprintf(
+            $message ?? 'Failed asserting that the Email has an attachment with name matching pattern "%s".',
+            $attachmentNamePattern,
         ));
     }
 }

--- a/tests/Bridge/Behat/email.feature
+++ b/tests/Bridge/Behat/email.feature
@@ -32,6 +32,8 @@ Feature: Testing emails
 
     Then I select email #0
     And this email has 1 attachment
+    And this email has attachment named "attachment.txt"
+    And this email has attachment name matching "#^attachment#"
 
   Scenario: I can test if emails text body contains
     When I send an email:

--- a/tests/MailerAssertionsTest.php
+++ b/tests/MailerAssertionsTest.php
@@ -529,6 +529,42 @@ class MailerAssertionsTest extends TestCase
         $this->mailerAssertions->assertEmailSubjectMatches($email, '/^[A-Z]oodbye/');
     }
 
+    public function testAssertEmailAttachmentNameSame(): void
+    {
+        $email = $this->createEmail()->attach('Hello world!', 'message.txt');
+
+        $this->mailerAssertions->assertEmailAttachmentNameSame($email, 'message.txt');
+
+        $this->addToAssertionCount(1);
+    }
+
+    public function testAssertEmailAttachmentNameSameFailing(): void
+    {
+        $this->expectDeprecationMessage('Failed asserting that the Email has an attachment with name "not message.txt".');
+
+        $email = $this->createEmail()->attach('Hello world!', 'message.txt');
+
+        $this->mailerAssertions->assertEmailAttachmentNameSame($email, 'not message.txt');
+    }
+
+    public function testAssertEmailAttachmentNameMatches(): void
+    {
+        $email = $this->createEmail()->attach('Hello world!', 'message.txt');
+
+        $this->mailerAssertions->assertEmailAttachmentNameMatches($email, '/^message/');
+
+        $this->addToAssertionCount(1);
+    }
+
+    public function testAssertEmailAttachmentNameMatchesFailing(): void
+    {
+        $this->expectDeprecationMessage('Failed asserting that the Email has an attachment with name matching pattern "/^not message/".');
+
+        $email = $this->createEmail()->attach('Hello world!', 'message.txt');
+
+        $this->mailerAssertions->assertEmailAttachmentNameMatches($email, '/^not message/');
+    }
+
     protected function createMessageEvent(RawMessage $message, string $transport = 'null://'): MessageEvent
     {
         return new MessageEvent($message, Envelope::create($message), $transport);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #12   <!-- #-prefixed issue number(s), if any -->

<!--
Write a short README entry for your feature/bugfix here (replace this comment block.),
this will help people understand your PR.
-->

- `@Then this email has attachment named :name`
- `@Then this email has attachment name matching :regex`