### PR TITLE
Don't autowire controllers if no PSR-7 implementation is found, close #16

### DIFF
--- a/.github/nyholm_psr7.yaml
+++ b/.github/nyholm_psr7.yaml
@@ -1,0 +1,21 @@
+services:
+    # Register nyholm/psr7 services for autowiring with PSR-17 (HTTP factories)
+    Psr\Http\Message\RequestFactoryInterface: '@nyholm.psr7.psr17_factory'
+    Psr\Http\Message\ResponseFactoryInterface: '@nyholm.psr7.psr17_factory'
+    Psr\Http\Message\ServerRequestFactoryInterface: '@nyholm.psr7.psr17_factory'
+    Psr\Http\Message\StreamFactoryInterface: '@nyholm.psr7.psr17_factory'
+    Psr\Http\Message\UploadedFileFactoryInterface: '@nyholm.psr7.psr17_factory'
+    Psr\Http\Message\UriFactoryInterface: '@nyholm.psr7.psr17_factory'
+
+    # Register nyholm/psr7 services for autowiring with HTTPlug factories
+    Http\Message\MessageFactory: '@nyholm.psr7.httplug_factory'
+    Http\Message\RequestFactory: '@nyholm.psr7.httplug_factory'
+    Http\Message\ResponseFactory: '@nyholm.psr7.httplug_factory'
+    Http\Message\StreamFactory: '@nyholm.psr7.httplug_factory'
+    Http\Message\UriFactory: '@nyholm.psr7.httplug_factory'
+
+    nyholm.psr7.psr17_factory:
+        class: Nyholm\Psr7\Factory\Psr17Factory
+
+    nyholm.psr7.httplug_factory:
+        class: Nyholm\Psr7\Factory\HttplugFactory

--- a/.github/psr_http_message_bridge.yaml
+++ b/.github/psr_http_message_bridge.yaml
@@ -1,0 +1,19 @@
+services:
+    _defaults:
+        autowire: true
+        autoconfigure: true
+
+    Symfony\Bridge\PsrHttpMessage\HttpFoundationFactoryInterface: '@Symfony\Bridge\PsrHttpMessage\Factory\HttpFoundationFactory'
+
+    Symfony\Bridge\PsrHttpMessage\HttpMessageFactoryInterface: '@Symfony\Bridge\PsrHttpMessage\Factory\PsrHttpFactory'
+
+    Symfony\Bridge\PsrHttpMessage\Factory\HttpFoundationFactory: null
+    Symfony\Bridge\PsrHttpMessage\Factory\PsrHttpFactory: null
+
+    # Uncomment the following line to allow controllers to receive a
+    # PSR-7 server request object instead of an HttpFoundation request
+    Symfony\Bridge\PsrHttpMessage\ArgumentValueResolver\PsrServerRequestResolver: null
+
+    # Uncomment the following line to allow controllers to return a
+    # PSR-7 response object instead of an HttpFoundation response
+    Symfony\Bridge\PsrHttpMessage\EventListener\PsrResponseListener: null

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,6 +123,7 @@ jobs:
                   node-version: ${{ env.NODE_VERSION }}
 
             - run: composer install --no-progress --no-suggest --prefer-dist --optimize-autoloader
+            - run: composer require symfony/psr7-pack
 
             - run: composer server-start
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,6 +126,7 @@ jobs:
             - run: composer install --no-progress --no-suggest --prefer-dist --optimize-autoloader
             - run: composer require symfony/psr7-pack
             - run: cp .github/psr_http_message_bridge.yaml fixtures/applications/Symfony/config/packages
+            - run: cp .github/nyholm_psr7.yaml fixtures/applications/Symfony/config/packages
 
             - run: composer server-start
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
                   node-version: ${{ env.NODE_VERSION }}
 
             - run: composer install --prefer-dist --no-interaction --no-progress
+            - run: composer require symfony/psr7-pack # To make PHPStan and me happy, it prevent me to write stubs for PHPStan
 
             - run: composer validate --strict
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,7 @@ jobs:
 
             - run: composer install --no-progress --no-suggest --prefer-dist --optimize-autoloader
             - run: composer require symfony/psr7-pack
+            - run: cp .github/psr_http_message_bridge.yaml fixtures/applications/Symfony/config/packages
 
             - run: composer server-start
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,8 @@ jobs:
                   node-version: ${{ env.NODE_VERSION }}
 
             - run: composer install --prefer-dist --no-interaction --no-progress
+            - run: cp .github/psr_http_message_bridge.yaml fixtures/applications/Symfony/config/packages
+            - run: cp .github/nyholm_psr7.yaml fixtures/applications/Symfony/config/packages
             - run: composer require symfony/psr7-pack # To make PHPStan and me happy, it prevent me to write stubs for PHPStan
 
             - run: composer validate --strict
@@ -124,9 +126,9 @@ jobs:
                   node-version: ${{ env.NODE_VERSION }}
 
             - run: composer install --no-progress --no-suggest --prefer-dist --optimize-autoloader
-            - run: composer require symfony/psr7-pack
             - run: cp .github/psr_http_message_bridge.yaml fixtures/applications/Symfony/config/packages
             - run: cp .github/nyholm_psr7.yaml fixtures/applications/Symfony/config/packages
+            - run: composer require symfony/psr7-pack
 
             - run: composer server-start
 

--- a/README.md
+++ b/README.md
@@ -87,14 +87,40 @@ If you want to add more assertions but can't extend from `MailerContext`, you ca
 
 ##### Installing a PSR-7 implementation
 
-You can install `symfony/psr7-pack` which will install:
+You can install `symfony/psr7-pack` which will install all you need:
 
 - [nyholm/psr7](https://github.com/Nyholm/psr7) for the PSR-7 implementation
 - [symfony/psr-http-message-bridge](https://github.com/symfony/psr-http-message-bridge) for the Symfony integration
 
-Those dependencies will make sure that the PSR-7 compatible controllers provided by SymfonyMailerTesting will be compatible with Symfony.
+Those dependencies will make sure that the PSR-7 compatible controllers provided by SymfonyMailerTesting will be working with Symfony.
 
 ##### Configuring Symfony
+
+You must configuring the Symfony PSR HTTP Message Bridge. 
+The following file is automatically created by Symfony Flex but services `Symfony\Bridge\PsrHttpMessage\ArgumentValueResolver\PsrServerRequestResolver`
+and `Symfony\Bridge\PsrHttpMessage\EventListener\PsrResponseListener` are not enabled by default, **you must enable those services**:
+```yaml
+# config/packages/psr_http_message_bridge.yaml
+services:
+    _defaults:
+        autowire: true
+        autoconfigure: true
+
+    Symfony\Bridge\PsrHttpMessage\HttpFoundationFactoryInterface: '@Symfony\Bridge\PsrHttpMessage\Factory\HttpFoundationFactory'
+
+    Symfony\Bridge\PsrHttpMessage\HttpMessageFactoryInterface: '@Symfony\Bridge\PsrHttpMessage\Factory\PsrHttpFactory'
+
+    Symfony\Bridge\PsrHttpMessage\Factory\HttpFoundationFactory: null
+    Symfony\Bridge\PsrHttpMessage\Factory\PsrHttpFactory: null
+
+    # Uncomment the following line to allow controllers to receive a
+    # PSR-7 server request object instead of an HttpFoundation request
+    Symfony\Bridge\PsrHttpMessage\ArgumentValueResolver\PsrServerRequestResolver: null
+
+    # Uncomment the following line to allow controllers to return a
+    # PSR-7 response object instead of an HttpFoundation response
+    Symfony\Bridge\PsrHttpMessage\EventListener\PsrResponseListener: null
+```
 
 Then you have to import the routes:
 
@@ -104,7 +130,7 @@ symfony_mailer_testing:
   resource: '@SymfonyMailerTestingBundle/Resources/config/routing.yaml'
 ```
 
-And configure the firewall to disallow the firewall on `/_symfony_mailer_testing`:
+And disable the firewall and access control on `/_symfony_mailer_testing`:
 
 ```diff
     firewalls:

--- a/README.md
+++ b/README.md
@@ -87,20 +87,12 @@ If you want to add more assertions but can't extend from `MailerContext`, you ca
 
 ##### Installing a PSR-7 implementation
 
-First, you need to install a PSR-7 implementation, e.g. [nyholm/psr7](https://github.com/Nyholm/psr7) :
+You can install `symfony/psr7-pack` which will install:
 
-```console
-$ composer require nyholm/psr7
-```
+- [nyholm/psr7](https://github.com/Nyholm/psr7) for the PSR-7 implementation
+- [symfony/psr-http-message-bridge](https://github.com/symfony/psr-http-message-bridge) for the Symfony integration
 
-Then you need to install the [Sensio FrameworkExtraBundle](https://github.com/sensiolabs/SensioFrameworkExtraBundle) and [Symfony PSR-7 Bridge](https://github.com/symfony/psr-http-message-bridge):
-
-```console
-$ composer require sensio/framework-extra-bundle
-$ composer require --dev symfony/psr-http-message-bridge
-```
-
-Those dependencies will make sure that the PSR-7 compatible [`MailerController.php`](./src/MailerController.php) will be compatible with Symfony.
+Those dependencies will make sure that the PSR-7 compatible controllers provided by SymfonyMailerTesting will be compatible with Symfony.
 
 ##### Configuring Symfony
 

--- a/README.md
+++ b/README.md
@@ -96,9 +96,11 @@ Those dependencies will make sure that the PSR-7 compatible controllers provided
 
 ##### Configuring Symfony
 
-You must configuring the Symfony PSR HTTP Message Bridge. 
-The following file is automatically created by Symfony Flex but services `Symfony\Bridge\PsrHttpMessage\ArgumentValueResolver\PsrServerRequestResolver`
-and `Symfony\Bridge\PsrHttpMessage\EventListener\PsrResponseListener` are not enabled by default, **you must enable those services**:
+You must configuring the Symfony PSR HTTP Message Bridge and the PSR-7 integration. 
+
+The following files are automatically created by Symfony Flex but can require some configuration: 
+- `config/packages/psr_http_message_bridge.yaml`, **ensure services `Symfony\Bridge\PsrHttpMessage\ArgumentValueResolver\PsrServerRequestResolver`
+  and `Symfony\Bridge\PsrHttpMessage\EventListener\PsrResponseListener` are enabled**:
 ```yaml
 # config/packages/psr_http_message_bridge.yaml
 services:
@@ -121,6 +123,32 @@ services:
     # PSR-7 response object instead of an HttpFoundation response
     Symfony\Bridge\PsrHttpMessage\EventListener\PsrResponseListener: null
 ```
+- `config/packages/nyholm_psr7.yaml`:
+```yaml
+# config/packages/nyholm_psr7.yaml
+services:
+    # Register nyholm/psr7 services for autowiring with PSR-17 (HTTP factories)
+    Psr\Http\Message\RequestFactoryInterface: '@nyholm.psr7.psr17_factory'
+    Psr\Http\Message\ResponseFactoryInterface: '@nyholm.psr7.psr17_factory'
+    Psr\Http\Message\ServerRequestFactoryInterface: '@nyholm.psr7.psr17_factory'
+    Psr\Http\Message\StreamFactoryInterface: '@nyholm.psr7.psr17_factory'
+    Psr\Http\Message\UploadedFileFactoryInterface: '@nyholm.psr7.psr17_factory'
+    Psr\Http\Message\UriFactoryInterface: '@nyholm.psr7.psr17_factory'
+
+    # Register nyholm/psr7 services for autowiring with HTTPlug factories
+    Http\Message\MessageFactory: '@nyholm.psr7.httplug_factory'
+    Http\Message\RequestFactory: '@nyholm.psr7.httplug_factory'
+    Http\Message\ResponseFactory: '@nyholm.psr7.httplug_factory'
+    Http\Message\StreamFactory: '@nyholm.psr7.httplug_factory'
+    Http\Message\UriFactory: '@nyholm.psr7.httplug_factory'
+
+    nyholm.psr7.psr17_factory:
+        class: Nyholm\Psr7\Factory\Psr17Factory
+
+    nyholm.psr7.httplug_factory:
+        class: Nyholm\Psr7\Factory\HttplugFactory
+```
+
 
 Then you have to import the routes:
 

--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,6 @@
     "phpstan/phpstan-symfony": "^0.12.6",
     "phpstan/phpstan-webmozart-assert": "^0.12.4",
     "phpunit/phpunit": "^8.5.2",
-    "sensio/framework-extra-bundle": "^5.5",
     "symfony/framework-bundle": "^4.4.1 || ^5.0"
   },
   "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,6 @@
     "behat/behat": "^3.6",
     "friends-of-behat/symfony-extension": "^2.1",
     "friendsofphp/php-cs-fixer": "^2.16",
-    "nyholm/psr7": "^1.2",
     "phpspec/phpspec": "^6.1",
     "phpstan/phpstan": "^0.12.23",
     "phpstan/phpstan-phpunit": "^0.12.8",
@@ -49,8 +48,7 @@
     "phpstan/phpstan-webmozart-assert": "^0.12.4",
     "phpunit/phpunit": "^8.5.2",
     "sensio/framework-extra-bundle": "^5.5",
-    "symfony/framework-bundle": "^4.4.1 || ^5.0",
-    "symfony/psr-http-message-bridge": "^2.0"
+    "symfony/framework-bundle": "^4.4.1 || ^5.0"
   },
   "autoload": {
     "psr-4": {

--- a/fixtures/applications/Symfony/config/bundles.php
+++ b/fixtures/applications/Symfony/config/bundles.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 return [
     Symfony\Bundle\FrameworkBundle\FrameworkBundle::class                              => ['all' => true],
-    Sensio\Bundle\FrameworkExtraBundle\SensioFrameworkExtraBundle::class               => ['all' => true],
     FriendsOfBehat\SymfonyExtension\Bundle\FriendsOfBehatSymfonyExtensionBundle::class => ['test' => true],
     Kocal\SymfonyMailerTesting\Bridge\Symfony\SymfonyMailerTestingBundle::class        => ['test' => true],
 ];

--- a/fixtures/applications/Symfony/config/packages/psr_http_message_bridge.yaml
+++ b/fixtures/applications/Symfony/config/packages/psr_http_message_bridge.yaml
@@ -1,0 +1,19 @@
+services:
+    _defaults:
+        autowire: true
+        autoconfigure: true
+
+    Symfony\Bridge\PsrHttpMessage\HttpFoundationFactoryInterface: '@Symfony\Bridge\PsrHttpMessage\Factory\HttpFoundationFactory'
+
+    Symfony\Bridge\PsrHttpMessage\HttpMessageFactoryInterface: '@Symfony\Bridge\PsrHttpMessage\Factory\PsrHttpFactory'
+
+    Symfony\Bridge\PsrHttpMessage\Factory\HttpFoundationFactory: null
+    Symfony\Bridge\PsrHttpMessage\Factory\PsrHttpFactory: null
+
+    # Uncomment the following line to allow controllers to receive a
+    # PSR-7 server request object instead of an HttpFoundation request
+    Symfony\Bridge\PsrHttpMessage\ArgumentValueResolver\PsrServerRequestResolver: null
+
+    # Uncomment the following line to allow controllers to return a
+    # PSR-7 response object instead of an HttpFoundation response
+    Symfony\Bridge\PsrHttpMessage\EventListener\PsrResponseListener: null

--- a/src/Bridge/Symfony/DependencyInjection/SymfonyMailerTestingExtension.php
+++ b/src/Bridge/Symfony/DependencyInjection/SymfonyMailerTestingExtension.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Kocal\SymfonyMailerTesting\Bridge\Symfony\DependencyInjection;
 
+use Kocal\SymfonyMailerTesting\Controller\MailerController;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\Extension;
@@ -19,5 +20,9 @@ class SymfonyMailerTestingExtension extends Extension
         );
 
         $loader->load('services.yaml');
+
+        if (!class_exists(\Psr\Http\Message\ResponseInterface::class)) {
+            $container->removeDefinition(MailerController::class);
+        }
     }
 }

--- a/src/Bridge/Symfony/DependencyInjection/SymfonyMailerTestingExtension.php
+++ b/src/Bridge/Symfony/DependencyInjection/SymfonyMailerTestingExtension.php
@@ -21,7 +21,7 @@ class SymfonyMailerTestingExtension extends Extension
 
         $loader->load('services.yaml');
 
-        if (!class_exists(\Psr\Http\Message\ResponseInterface::class)) {
+        if (!interface_exists(\Psr\Http\Message\ResponseInterface::class)) {
             $container->removeDefinition(MailerController::class);
         }
     }


### PR DESCRIPTION
Also simplified the installation of a PSR-7 implementation + Symfony integration by using https://github.com/symfony/psr7-pack, ~~but that's not released on packagist yet~~.