### PR TITLE
Add compatibility for PHPUnit 10 and Symfony 7.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,68 +1,68 @@
 {
-  "name": "kocal/symfony-mailer-testing",
-  "description": "Test your emails with Behat and Cypress, when using the Symfony Mailer component.",
-  "license": "MIT",
-  "authors": [
-    {
-      "name": "Hugo Alliaume",
-      "email": "hugo@alliau.me"
-    }
-  ],
-  "config": {
-    "sort-packages": true
-  },
-  "scripts": {
-    "bin": "echo 'bin not installed'",
-    "phpstan": "phpstan analyze --ansi",
-    "php-cs-fixer": "php-cs-fixer fix -v",
-    "php-cs-fixer@ci": "php-cs-fixer fix -v --diff --dry-run",
-    "phpunit": "phpunit",
-    "behat": "behat --colors",
-    "server-start": "APP_ENV=test ./bin/symfony server:start --no-tls --dir fixtures/applications/Symfony --daemon",
-    "server-stop": "APP_ENV=test ./bin/symfony server:stop --dir fixtures/applications/Symfony",
-    "auto": [
-      "cd fixtures/applications/Symfony && APP_ENV=test bin/console cache:clear"
+    "name": "kocal/symfony-mailer-testing",
+    "description": "Test your emails with Behat and Cypress, when using the Symfony Mailer component.",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Hugo Alliaume",
+            "email": "hugo@alliau.me"
+        }
     ],
-    "post-install-cmd": [
-      "@composer bin all install --ansi",
-      "@auto"
-    ],
-    "post-update-cmd": [
-      "@composer bin all update --ansi",
-      "@auto"
-    ]
-  },
-  "require": {
-    "php": "^7.4 || ^8.0",
-    "ext-json": "*",
-    "phpunit/phpunit": "^8.5 || ^9.0",
-    "symfony/console": "^4.4 || ^5.0 || ^6.0",
-    "symfony/mailer": "^4.4 || ^5.0 || ^6.0"
-  },
-  "require-dev": {
-    "bamarni/composer-bin-plugin": "^1.4",
-    "behat/behat": "^3.6",
-    "friends-of-behat/symfony-extension": "^2.2",
-    "symfony/framework-bundle": "^4.4.14 || ^5.0 || ^6.0",
-    "symfony/psr7-pack": "^1.0"
-  },
-  "autoload": {
-    "psr-4": {
-      "Kocal\\SymfonyMailerTesting\\": "src/"
+    "config": {
+        "sort-packages": true
+    },
+    "scripts": {
+        "bin": "echo 'bin not installed'",
+        "phpstan": "phpstan analyze --ansi",
+        "php-cs-fixer": "php-cs-fixer fix -v",
+        "php-cs-fixer@ci": "php-cs-fixer fix -v --diff --dry-run",
+        "phpunit": "phpunit",
+        "behat": "behat --colors",
+        "server-start": "APP_ENV=test ./bin/symfony server:start --no-tls --dir fixtures/applications/Symfony --daemon",
+        "server-stop": "APP_ENV=test ./bin/symfony server:stop --dir fixtures/applications/Symfony",
+        "auto": [
+            "cd fixtures/applications/Symfony && APP_ENV=test bin/console cache:clear"
+        ],
+        "post-install-cmd": [
+            "@composer bin all install --ansi",
+            "@auto"
+        ],
+        "post-update-cmd": [
+            "@composer bin all update --ansi",
+            "@auto"
+        ]
+    },
+    "require": {
+        "php": "^7.4 || ^8.0",
+        "ext-json": "*",
+        "phpunit/phpunit": "^8.5 || ^9.0 || ^10.0",
+        "symfony/console": "^4.4 || ^5.0 || ^6.0 || ^7.0",
+        "symfony/mailer": "^4.4 || ^5.0 || ^6.0 || ^7.0"
+    },
+    "require-dev": {
+        "bamarni/composer-bin-plugin": "^1.4",
+        "behat/behat": "^3.6",
+        "friends-of-behat/symfony-extension": "^2.2",
+        "symfony/framework-bundle": "^4.4.14 || ^5.0 || ^6.0 || ^7.0",
+        "symfony/psr7-pack": "^1.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "Kocal\\SymfonyMailerTesting\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Kocal\\SymfonyMailerTesting\\Tests\\": "tests/",
+            "Kocal\\SymfonyMailerTesting\\Tests\\Bridge\\Behat\\": "tests/Bridge/Behat/bootstrap/",
+            "Kocal\\SymfonyMailerTesting\\Fixtures\\": "fixtures/",
+            "Kocal\\SymfonyMailerTesting\\Fixtures\\Applications\\": "fixtures/applications/",
+            "Kocal\\SymfonyMailerTesting\\Fixtures\\Applications\\Symfony\\App\\": "fixtures/applications/Symfony/src/"
+        }
+    },
+    "extra": {
+        "bamarni-bin": {
+            "target-directory": "tools"
+        }
     }
-  },
-  "autoload-dev": {
-    "psr-4": {
-      "Kocal\\SymfonyMailerTesting\\Tests\\": "tests/",
-      "Kocal\\SymfonyMailerTesting\\Tests\\Bridge\\Behat\\": "tests/Bridge/Behat/bootstrap/",
-      "Kocal\\SymfonyMailerTesting\\Fixtures\\": "fixtures/",
-      "Kocal\\SymfonyMailerTesting\\Fixtures\\Applications\\": "fixtures/applications/",
-      "Kocal\\SymfonyMailerTesting\\Fixtures\\Applications\\Symfony\\App\\": "fixtures/applications/Symfony/src/"
-    }
-  },
-  "extra": {
-    "bamarni-bin": {
-      "target-directory": "tools"
-    }
-  }
 }


### PR DESCRIPTION
Related to: #33  

I've been added compatibility to use this library with PHPUnit 10. I also add compatibility for Symfony 7, but main library behat/behat is now pending to include this compatibility. So, it will be useful soon. If someone prefer, I can keep only the compatibility with PHPUnit 10

![imagen](https://github.com/Kocal/SymfonyMailerTesting/assets/1655777/bf13ea64-b43e-4715-b142-974824500c76)
